### PR TITLE
Add GetLazyRootDirectory util

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,5 +1,11 @@
 package utils
 
+import (
+	"log"
+	"os"
+	"path/filepath"
+)
+
 // Min returns the minimum of two integers
 func Min(x, y int) int {
 	if x < y {
@@ -8,9 +14,38 @@ func Min(x, y int) int {
 	return y
 }
 
+// Max returns the maximum of two integers
 func Max(x, y int) int {
 	if x > y {
 		return x
 	}
 	return y
+}
+
+// GetLazyRootDirectory finds lazy project root directory.
+//
+// It's used for cheatsheet scripts and integration tests. Not to be confused with finding the
+// root directory of _any_ random repo.
+func GetLazyRootDirectory() string {
+	path, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	for {
+		_, err := os.Stat(filepath.Join(path, ".git"))
+		if err == nil {
+			return path
+		}
+
+		if !os.IsNotExist(err) {
+			panic(err)
+		}
+
+		path = filepath.Dir(path)
+
+		if path == "/" {
+			log.Fatal("must run in lazy project folder or child folder")
+		}
+	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -22,7 +22,7 @@ func Max(x, y int) int {
 	return y
 }
 
-// GetLazyRootDirectory finds lazy project root directory.
+// GetLazyRootDirectory finds a lazy project root directory.
 //
 // It's used for cheatsheet scripts and integration tests. Not to be confused with finding the
 // root directory of _any_ random repo.

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -36,3 +36,9 @@ func TestMin(t *testing.T) {
 		assert.EqualValues(t, s.expected, Min(s.a, s.b))
 	}
 }
+
+func TestGetLazyRootDirectory(t *testing.T) {
+	assert.NotPanics(t, func() {
+		GetLazyRootDirectory()
+	})
+}


### PR DESCRIPTION
## Context
After digging a bit into `lazygit` and `lazydocker`'s cheatsheet files, i quickly found wouldn't make sense to generalize them as they're somewhat specific for each project. See difference: [lazygit file](https://github.com/jesseduffield/lazygit/blob/master/pkg/cheatsheet/generate.go#L127) and [lazydocker file]( https://github.com/gusandrioli/lazydocker/blob/c56256358ab4b3b1ad822468212f5ad88c15ee19/pkg/cheatsheet/generate.go#L77).

For this reason, I only added `GetLazyRootDirectory()` as it's very generic. If approved, i can update both projects to use this one for now. 