### PR TITLE
Add clamp func

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -22,6 +22,7 @@ func Max(x, y int) int {
 	return y
 }
 
+// Clamp returns a value x restricted between min and max
 func Clamp(x int, min int, max int) int {
 	if x < min {
 		return min

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -22,6 +22,15 @@ func Max(x, y int) int {
 	return y
 }
 
+func Clamp(x int, min int, max int) int {
+	if x < min {
+		return min
+	} else if x > max {
+		return max
+	}
+	return x
+}
+
 // GetLazyRootDirectory finds a lazy project root directory.
 //
 // It's used for cheatsheet scripts and integration tests. Not to be confused with finding the

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -9,9 +9,9 @@ import (
 // TestMin is a function.
 func TestMin(t *testing.T) {
 	type scenario struct {
-		a    int
-		b    int
-		want int
+		a        int
+		b        int
+		expected int
 	}
 
 	scenarios := []scenario{
@@ -33,7 +33,7 @@ func TestMin(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		assert.EqualValues(t, s.want, Min(s.a, s.b))
+		assert.EqualValues(t, s.expected, Min(s.a, s.b))
 	}
 }
 
@@ -46,21 +46,21 @@ func TestClamp(t *testing.T) {
 		want int
 	}{
 		{
-			"success",
+			"successX",
 			5,
 			1,
 			10,
 			5,
 		},
 		{
-			"success",
+			"successMin",
 			-5,
 			1,
 			10,
 			1,
 		},
 		{
-			"success",
+			"successMax",
 			15,
 			1,
 			10,

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -9,9 +9,9 @@ import (
 // TestMin is a function.
 func TestMin(t *testing.T) {
 	type scenario struct {
-		a        int
-		b        int
-		expected int
+		a    int
+		b    int
+		want int
 	}
 
 	scenarios := []scenario{
@@ -33,7 +33,45 @@ func TestMin(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		assert.EqualValues(t, s.expected, Min(s.a, s.b))
+		assert.EqualValues(t, s.want, Min(s.a, s.b))
+	}
+}
+
+func TestClamp(t *testing.T) {
+	tests := []struct {
+		name string
+		x    int
+		min  int
+		max  int
+		want int
+	}{
+		{
+			"success",
+			5,
+			1,
+			10,
+			5,
+		},
+		{
+			"success",
+			-5,
+			1,
+			10,
+			1,
+		},
+		{
+			"success",
+			15,
+			1,
+			10,
+			10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, Clamp(tt.x, tt.min, tt.max))
+		})
 	}
 }
 


### PR DESCRIPTION
## Context
While substituting `GetLazyRootDirectory` funcs on `lazygit` I faced a conflict on `pkg/integration/clients/tui.go` as it's using `Clamp` from `lazygit/pkg/utils`. So adding this here and updating both would solve the issue and contribute to the goal of this package. 